### PR TITLE
use push_preview = true in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,4 +12,8 @@ makedocs(
               "Reference" => "reference.md"]
 )
 
-deploydocs(repo = "github.com/JuliaSmoothOptimizers/NCL.jl.git", devbranch = "main")
+deploydocs(
+  repo = "github.com/JuliaSmoothOptimizers/NCL.jl.git",
+  push_preview = true,
+  devbranch = "main",
+)


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.