### PR TITLE
Support maximization problems in NCLModel

### DIFF
--- a/src/NCLModel.jl
+++ b/src/NCLModel.jl
@@ -1,5 +1,3 @@
-# TODO: accept maximization problems
-
 import NLPModels: increment!
 
 export NCLModel
@@ -95,7 +93,7 @@ function NCLModel(
     ncon = get_ncon(nlp),
     lcon = get_lcon(nlp),
     ucon = get_ucon(nlp),
-    minimize = true,  # get_minimize(nlp)
+    minimize = true,
     islp = false,
     sparse_jacobian = get_sparse_jacobian(nlp),
     sparse_hessian = get_sparse_hessian(nlp),
@@ -107,7 +105,6 @@ function NCLModel(
     hprod_available = get_hprod_available(nlp),
   )
 
-  get_minimize(nlp) || error("only minimization problems are currently supported")
   return NCLModel{T, S, typeof(nlp)}(nlp, nx, nr, resid_linear, meta, Counters(), y, ρ)
 end
 
@@ -117,9 +114,8 @@ function NLPModels.obj(ncl::NCLModel{T, S, M}, xr::S) where {T, S, M <: Abstract
   x = view(xr, 1:(ncl.nx))
   r = view(xr, (ncl.nx + 1):(ncl.nx + ncl.nr))
   obj_val = obj(ncl.nlp, x)
-  get_minimize(ncl) || (obj_val *= -1)
+  get_minimize(ncl.nlp) || (obj_val *= -1)
   obj_res = ncl.y' * r + ncl.ρ * dot(r, r) / 2
-  # get_minimize(ncl) || (obj_res *= -1)
   return obj_val + obj_res
 end
 
@@ -133,10 +129,9 @@ function NLPModels.grad!(
   x = view(xr, 1:(ncl.nx))
   orig_gx = view(gx, 1:(ncl.nx))
   grad!(ncl.nlp, x, orig_gx)
-  get_minimize(ncl) || (gx[1:(ncl.nx)] .*= -1)
+  get_minimize(ncl.nlp) || (gx[1:(ncl.nx)] .*= -1)
   r = view(xr, (ncl.nx + 1):(ncl.nx + ncl.nr))
   gx[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= ncl.ρ * r .+ ncl.y
-  # get_minimize(ncl) || (gx[ncl.nx + 1 : ncl.nx + ncl.nr] .*= -1)
   return gx
 end
 
@@ -170,14 +165,9 @@ function NLPModels.hess_coord!(
   orig_nnzh = get_nnzh(ncl.nlp)
   x = view(xr, 1:(ncl.nx))
   orig_hvals = view(hvals, 1:orig_nnzh)
-  hess_coord!(ncl.nlp, x, orig_hvals; obj_weight = obj_weight)
-  # get_minimize(ncl) || (hvals[1:orig_nnzh] .*= -1)
+  inner_obj_weight = get_minimize(ncl.nlp) ? obj_weight : -obj_weight
+  hess_coord!(ncl.nlp, x, orig_hvals; obj_weight = inner_obj_weight)
   hvals[(orig_nnzh + 1):nnzh] .= ncl.ρ * obj_weight
-  # if get_minimize(ncl)
-  # hvals[(orig_nnzh + 1):nnzh] .= ncl.ρ
-  # else
-  #   hvals[orig_nnzh + 1 : nnzh] .= -ncl.ρ
-  # end
   return hvals
 end
 
@@ -196,14 +186,9 @@ function NLPModels.hess_coord!(
   orig_nnzh = get_nnzh(ncl.nlp)
   x = view(xr, 1:(ncl.nx))
   orig_hvals = view(hvals, 1:orig_nnzh)
-  hess_coord!(ncl.nlp, x, y, orig_hvals; obj_weight = obj_weight)
-  # get_minimize(ncl) || (hvals[1:orig_nnzh] .*= -1)
+  inner_obj_weight = get_minimize(ncl.nlp) ? obj_weight : -obj_weight
+  hess_coord!(ncl.nlp, x, y, orig_hvals; obj_weight = inner_obj_weight)
   hvals[(orig_nnzh + 1):nnzh] .= ncl.ρ * obj_weight
-  # if get_minimize(ncl)
-  # hvals[(orig_nnzh + 1):nnzh] .= ncl.ρ
-  # else
-  #   hvals[orig_nnzh + 1 : nnzh] .= -ncl.ρ
-  # end
   return hvals
 end
 
@@ -218,18 +203,13 @@ function NLPModels.hprod!(
   increment!(ncl, :neval_hprod)
   x = view(xr, 1:(ncl.nx))
   orig_hv = view(hv, 1:(ncl.nx))
-  hprod!(ncl.nlp, x, view(v, 1:(ncl.nx)), orig_hv; obj_weight = obj_weight)
-  # get_minimize(ncl) || (orig_hv .*= -1)
+  inner_obj_weight = get_minimize(ncl.nlp) ? obj_weight : -obj_weight
+  hprod!(ncl.nlp, x, view(v, 1:(ncl.nx)), orig_hv; obj_weight = inner_obj_weight)
   if obj_weight == zero(T)
     hv[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= 0
   else
     hv[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= obj_weight * ncl.ρ * v[(ncl.nx + 1):(ncl.nx + ncl.nr)]
   end
-  # if get_minimize(ncl)
-  # hv[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= ncl.ρ * v[(ncl.nx + 1):(ncl.nx + ncl.nr)]
-  # else
-  #   hv[ncl.nx + 1 : ncl.nx + ncl.nr] .= -ncl.ρ * v[ncl.nx + 1 : ncl.nx + ncl.nr]
-  # end
   return hv
 end
 
@@ -246,18 +226,13 @@ function NLPModels.hprod!(
   increment!(ncl, :neval_hprod)
   x = view(xr, 1:(ncl.nx))
   orig_hv = view(hv, 1:(ncl.nx))
-  hprod!(ncl.nlp, x, y, view(v, 1:(ncl.nx)), orig_hv; obj_weight = obj_weight)
-  # get_minimize(ncl) || (orig_hv .*= -1)
+  inner_obj_weight = get_minimize(ncl.nlp) ? obj_weight : -obj_weight
+  hprod!(ncl.nlp, x, y, view(v, 1:(ncl.nx)), orig_hv; obj_weight = inner_obj_weight)
   if obj_weight == zero(T)
     hv[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= 0
   else
     hv[(ncl.nx + 1):(ncl.nx + ncl.nr)] .= obj_weight * ncl.ρ * v[(ncl.nx + 1):(ncl.nx + ncl.nr)]
   end
-  # if get_minimize(ncl)
-  #   hv[ncl.nx + 1 : ncl.nx + ncl.nr] .= ncl.ρ * v[ncl.nx + 1 : ncl.nx + ncl.nr]
-  # else
-  #   hv[ncl.nx + 1 : ncl.nx + ncl.nr] .= -ncl.ρ * v[ncl.nx + 1 : ncl.nx + ncl.nr]
-  # end
   return hv
 end
 

--- a/test/test_NCLModel.jl
+++ b/test/test_NCLModel.jl
@@ -34,6 +34,8 @@ function test_NCLModel()
 
   name = "Unit test problem"
   nlp::ADNLPModel = ADNLPModel(f, x0, lvar, uvar, A, c, lcon, ucon; name = name)
+  nlp_max::ADNLPModel =
+    ADNLPModel(f, x0, lvar, uvar, A, c, lcon, ucon; name = name * " (max)", minimize = false)
 
   ncl_nlin_res = NCLModel(nlp; resid = 1.0, resid_linear = false, y = [1.0, 1.0])
   ncl_nlin_res.y = y
@@ -41,6 +43,21 @@ function test_NCLModel()
 
   ncl_cons_res = NCLModel(nlp; resid = 1.0, resid_linear = true, y = [1.0, 1.0, 1.0, 1.0])
   ncl_cons_res.ρ = ρ
+
+  ncl_max = NCLModel(nlp_max; resid = 1.0, resid_linear = false, y = [1.0, 1.0])
+  ncl_max.y = y
+  ncl_max.ρ = ρ
+
+  @testset "NCLModel. Maximization input" begin
+    @test ncl_max.meta.minimize == true
+    @test obj(ncl_max, [0.5, 0.5, 0.0, -1.0]) == -1.0 - 1.0 + 0.5 * ρ * 1.0
+    @test grad(ncl_max, [0.5, 0.5, 0.0, -1.0]) == [-1.0, -1.0, 2.0, 1.0 - ρ]
+
+    h_errs = hessian_check_from_grad(ncl_max, x = [1.0, 0.5, 0.0, 1.0])
+    for k ∈ keys(h_errs)
+      @test length(h_errs[k]) == 0
+    end
+  end
 
   @testset "NCLModel. No linear residuals" begin
     @testset "NCLModel struct" begin


### PR DESCRIPTION
Started something. You can see what I changed:

- Removed TODO comments and removed the minimization-only constructor error in `NCLModel.jl:1`.
- Made objective/derivative sign handling depend on the original model direction:
- Objective sign conversion for max inputs in `NCLModel.jl:114`
- Gradient sign conversion for x-part in `NCLModel.jl:129`
- Hessian and Hessian-product use signed inner obj_weight in `NCLModel.jl:165`, `NCLModel.jl:186`, `NCLModel.jl:203` and `NCLModel.jl:226`
- Added a regression test for maximization input in `test_NCLModel.jl`.