### PR TITLE
Define modular solvers for IPOPT and KNITRO

### DIFF
--- a/ext/NCLIpoptExt.jl
+++ b/ext/NCLIpoptExt.jl
@@ -3,10 +3,33 @@ module NCLIpoptExt
 using NCL
 using NLPModels
 using NLPModelsIpopt
+using SolverCore
 
-function __init__()
-  @info "Registering NCL solver IPOPT"
-  NCL._register_solver!(:ipopt)
+mutable struct IpoptNCLSubSolver <: AbstractNCLSubSolver
+  solver::IpoptSolver
+  stats::GenericExecutionStats
+  dfeas_abs_tol::Float64  # IPOPT only supports Float64.
+  pfeas_abs_tol::Float64
+  compl_abs_tol::Float64
+  mu_init::Float64  # just for logging
+  name::String
+end
+
+# ... constructor
+function NCL.IpoptNCLSubSolver(::NCLModel{T, S, M}; kwargs...) where {T, S, M}
+  error("IPOPT only supports models with Float64 element type.")
+end
+
+function NCL.IpoptNCLSubSolver(
+  ncl_model::NCLModel{Float64, S, M};
+  dfeas_abs_tol::Float64 = 0.1,  # IPOPT stops when relative AND absolute tolerances are met.
+  pfeas_abs_tol::Float64 = 0.1,  # Set them to loose values by default.
+  compl_abs_tol::Float64 = 0.1,
+) where {S, M <: AbstractNLPModel{Float64, S}}
+  @debug "initializing IPOPT subproblem solver"
+  solver = IpoptSolver(ncl_model)
+  stats = GenericExecutionStats(ncl_model)
+  return IpoptNCLSubSolver(solver, stats, dfeas_abs_tol, pfeas_abs_tol, compl_abs_tol, 0.0, "IPOPT")
 end
 
 const ipopt_fixed_options = Dict(
@@ -15,8 +38,58 @@ const ipopt_fixed_options = Dict(
   :max_iter => 100,
 )
 
-function NCL._solve_ipopt(ncl::NLPModels.AbstractNLPModel; kwargs...)
-  return NLPModelsIpopt.ipopt(ncl; ipopt_fixed_options..., kwargs...)
+# TODO: need smarter initialization
+function compute_mu_init(outer_iter::Int)
+  mu_init = 1.0e-1
+  if 2 <= outer_iter < 4
+    mu_init = 1e-4
+  elseif 4 <= outer_iter < 6
+    mu_init = 1e-5
+  elseif 6 <= outer_iter < 8
+    mu_init = 1e-6
+  elseif 8 <= outer_iter < 10
+    mu_init = 1e-7
+  elseif outer_iter >= 10
+    mu_init = 1e-8
+  end
+  mu_init
+end
+
+# ... solve
+function (sub::IpoptNCLSubSolver)(
+  ncl_model::NCLModel,
+  outer_iter::Int,
+  rel_tol::Float64;
+  x0::AbstractVector = get_x0(ncl_model),
+  kwargs...,
+)
+
+  # prepare for warm start
+  # TODO: try solver.mu from the previous solve
+  # TODO: set bound_push?
+  sub.mu_init = compute_mu_init(outer_iter)
+
+  # warm-starting multipliers appears to help IPOPT
+  y0 = sub.stats.multipliers
+  zL0 = sub.stats.multipliers_L
+  zU0 = sub.stats.multipliers_U
+  return solve!(
+    sub.solver,
+    ncl_model,
+    sub.stats;
+    warm_start_init_point = outer_iter > 1 ? "yes" : "no",
+    x0 = x0,
+    y0 = y0,
+    zL0 = zL0,
+    zU0 = zU0,
+    mu_init = sub.mu_init,
+    dual_inf_tol = sub.dfeas_abs_tol,
+    constr_viol_tol = sub.pfeas_abs_tol,
+    compl_inf_tol = sub.compl_abs_tol,
+    tol = rel_tol,
+    ipopt_fixed_options...,
+    kwargs...,
+  )
 end
 
 end

--- a/ext/NCLKnitroExt.jl
+++ b/ext/NCLKnitroExt.jl
@@ -4,28 +4,98 @@ using NCL
 using NLPModels
 using KNITRO
 using NLPModelsKnitro
+using SolverCore
 
-function __init__()
-  if KNITRO.has_knitro()
-    @info "Registering NCL solver KNITRO"
-    NCL._register_solver!(:knitro)
-  else
-    @warn "KNITRO is not available"
-  end
+mutable struct KnitroNCLSubSolver <: AbstractNCLSubSolver
+  solver::KnitroSolver
+  stats::GenericExecutionStats
+  dfeas_abs_tol::Float64  # KNITRO only supports Float64.
+  pfeas_abs_tol::Float64
+  mu_init::Float64  # just for logging
+  name::String
+  z::Vector{Float64}  # KNITRO wants a single vector of dual variables
 end
 
-const knitro_fixed_options =
-  Dict(:algorithm => 1, :bar_directinterval => 0, :bar_initpt => 2, :outlev => 0, :maxit => 100)
+# ... constructor
+function NCL.KnitroNCLSubSolver(::NCLModel{T, S, M}; kwargs...) where {T, S, M}
+  error("KNITRO only supports models with Float64 element type.")
+end
 
-function NCL._solve_knitro(ncl::NLPModels.AbstractNLPModel; kwargs...)
-  if KNITRO.has_knitro()
-    return NLPModelsKnitro.knitro(ncl; knitro_fixed_options..., kwargs...)
+function NCL.KnitroNCLSubSolver(
+  ncl_model::NCLModel{Float64, S, M};
+  dfeas_abs_tol::Float64 = 0.1,  # KNITRO stops when relative AND absolute tolerances are met.
+  pfeas_abs_tol::Float64 = 0.1,  # Set them to loose values by default.
+) where {S, M <: AbstractNLPModel{Float64, S}}
+  @debug "initializing KNITRO subproblem solver"
+  solver = KnitroSolver(ncl_model)
+  stats = GenericExecutionStats(ncl_model)
+  z = similar(get_x0(ncl_model))
+  return KnitroNCLSubSolver(solver, stats, dfeas_abs_tol, pfeas_abs_tol, 0.0, "KNITRO", z)
+end
+
+const knitro_fixed_options = Dict(
+  :nlp_algorithm => 1,       # Interior/Direct
+  :bar_directinterval => 0,  # Only use direct linear algebra
+  :bar_initpt => 3,          # Center initial guess wrt two-sided bounds
+  :bar_murule => 1,          # Monotone
+  :outlev => 0,
+  :maxit => 100,
+)
+
+# TODO: need smarter initialization
+function compute_mu_init(outer_iter::Int)
+  mu_init = 1.0e-1
+  if 2 <= outer_iter < 4
+    mu_init = 1e-3
+  elseif 4 <= outer_iter < 6
+    mu_init = 1e-5
+  elseif 6 <= outer_iter < 8
+    mu_init = 1e-6
+  elseif 8 <= outer_iter < 10
+    mu_init = 1e-7
+  elseif outer_iter >= 10
+    mu_init = 1e-8
   end
+  mu_init
+end
 
-  error(
-    "Knitro support is loaded, but Knitro is not available/configured. " *
-    "Please check that the Knitro binary is installed and that its license is configured.",
+# ... solve
+function (sub::KnitroNCLSubSolver)(
+  ncl_model::NCLModel,
+  outer_iter::Int,
+  rel_tol::Float64;
+  x0::AbstractVector = get_x0(ncl_model),
+  kwargs...,
+)
+
+  # prepare for warm start
+  # TODO: try solver.mu from the previous solve
+  # TODO: set bound_push?
+  sub.mu_init = compute_mu_init(outer_iter)
+  bar_slackboundpush = sub.mu_init
+
+  # warm-starting multipliers doesn't seem to help KNITRO
+  y0 = sub.stats.multipliers
+  zL0 = sub.stats.multipliers_L
+  zU0 = sub.stats.multipliers_U
+  sub.z .== zL0 .- zU0
+
+  set_params!(
+    sub.solver,
+    x0 = x0,
+    y0 = y0,
+    z0 = sub.z,
+    bar_initmu = sub.mu_init,
+    bar_slackboundpush = bar_slackboundpush,
+    opttol_abs = sub.dfeas_abs_tol,
+    feastol_abs = sub.pfeas_abs_tol,
+    opttol = rel_tol,
+    feastol = rel_tol,
+    knitro_fixed_options...,
+    kwargs...,
   )
+
+  return solve!(sub.solver, ncl_model, sub.stats)
 end
 
 end

--- a/ext/NCLKnitroExt.jl
+++ b/ext/NCLKnitroExt.jl
@@ -78,7 +78,7 @@ function (sub::KnitroNCLSubSolver)(
   y0 = sub.stats.multipliers
   zL0 = sub.stats.multipliers_L
   zU0 = sub.stats.multipliers_U
-  sub.z .== zL0 .- zU0
+  sub.z .= zL0 .- zU0
 
   set_params!(
     sub.solver,

--- a/src/NCL.jl
+++ b/src/NCL.jl
@@ -17,7 +17,7 @@ end
 
 function KnitroNCLSubSolver(args...; kwargs...)
   error(
-    "Knitro support is not loaded. Install and load KNITRO.jl and NLPModelsKnitro.jl to use KnitroNCLSolver.",
+    "Knitro support is not loaded. Install and load KNITRO.jl and NLPModelsKnitro.jl to use KnitroNCLSubSolver.",
   )
 end
 

--- a/src/NCL.jl
+++ b/src/NCL.jl
@@ -6,44 +6,19 @@ using Printf
 using NLPModels
 using SolverCore
 
-const available_solvers = Symbol[]
+export IpoptNCLSubSolver
+export KnitroNCLSubSolver
 
-function _register_solver!(solver::Symbol)
-  solver in available_solvers || push!(available_solvers, solver)
-  return available_solvers
-end
-
-function _solve_ipopt(ncl::Any; kwargs...)
+function IpoptNCLSubSolver(args...; kwargs...)
   error(
-    "Ipopt support is not loaded. Install and load NLPModelsIpopt.jl in your environment to use solver=:ipopt.",
+    "Ipopt support is not loaded. Install and load NLPModelsIpopt.jl in your environment to use IpoptNCLSubSolver.",
   )
 end
 
-function _solve_knitro(ncl::Any; kwargs...)
+function KnitroNCLSubSolver(args...; kwargs...)
   error(
-    "Knitro support is not loaded. Install and load KNITRO.jl and NLPModelsKnitro.jl to use solver=:knitro.",
+    "Knitro support is not loaded. Install and load KNITRO.jl and NLPModelsKnitro.jl to use KnitroNCLSolver.",
   )
-end
-
-"""
-    _check_available_solver(solver::Symbol)
-
-Return an error if `solver` is not in `NCL.available_solvers`
-"""
-function _check_available_solver(solver::Symbol)
-  if isempty(available_solvers)
-    error(
-      "No NCL inner solver is available. Load NLPModelsIpopt.jl and/or KNITRO.jl + NLPModelsKnitro.jl.",
-    )
-  end
-
-  if !(solver in available_solvers)
-    s = "`solver` must be one of these: "
-    for x in available_solvers
-      s *= "`$x`, "
-    end
-    error(s[1:(end - 2)])
-  end
 end
 
 include("NCLModel.jl")

--- a/src/NCLSolve.jl
+++ b/src/NCLSolve.jl
@@ -1,4 +1,11 @@
-export NCLSolve
+export AbstractNCLSubSolver, NCLSolve
+
+# abstract type for NCL subproblem solvers
+abstract type AbstractNCLSubSolver <: AbstractOptimizationSolver end
+name(sub::AbstractNCLSubSolver) = sub.name
+stats(sub::AbstractNCLSubSolver) = sub.stats
+mu_init(sub::AbstractNCLSubSolver) = sub.mu_init
+failed(stats::GenericExecutionStats) = stats.status != :first_order
 
 # TODO: avoid infinite loop due to NCLModel not being generated
 NCLSolve(nlp::AbstractNLPModel, args...; kwargs...) = NCLSolve(NCLModel(nlp), args...; kwargs...)
@@ -8,16 +15,17 @@ function NCLSolve(
   opt_tol::Float64 = 1.0e-6,
   feas_tol::Float64 = 1.0e-6,
   max_iter_NCL::Int = 20,
-  solver = (:knitro in available_solvers) ? :knitro : :ipopt,
+  subsolver::AbstractNCLSubSolver = IpoptNCLSubSolver(ncl),
   verbose::Bool = true,
   kwargs...,  # will be passed directly to inner solver
 )
-  _check_available_solver(solver)
+  @info "NCL: using subsolver $(name(subsolver))"
+
+  NLPModels.reset!(ncl.nlp)
+  NLPModels.reset!(ncl)
 
   nx = ncl.nx
   nr = ncl.nr
-
-  mu_init = 1.0e-1
 
   τ_ρ = 10  # factor by which we increase ρ on unsuccessful iterations
   τ_η = 10  # factor by which we decrease η on successful iterations
@@ -38,6 +46,12 @@ function NCLSolve(
   best_rNorm = rNorm
   y = ncl.meta.y0
   z = zeros(ncl.meta.nvar)
+
+  # Initialize multipliers in subsolver.stats.
+  # The subsolver uses these to warm start.
+  sub_stats = stats(subsolver)
+  SolverCore.reset!(sub_stats)
+  set_multipliers!(sub_stats, y, z, z)
 
   if verbose
     @info @sprintf(
@@ -64,96 +78,21 @@ function NCLSolve(
   infeasible = false
   tired = k > max_iter_NCL
 
-  # set absolute tolerances once and for all
-  ipopt_options = Dict{Symbol, Any}(
-    :dual_inf_tol => ω,     # leave these at the initial ω value
-    :constr_viol_tol => ω,
-  )
-
-  knitro_options = Dict{Symbol, Any}(#:opttol_abs => ω,  # for some reason this doesn't work?!?!?
-  #:feastol_abs => ω,
-  )
-
-  local inner_stats, z
-  if has_bounds(ncl.nlp)
-    local zL, zU
-  end
-
   while !(converged || infeasible || tired)
     k += 1
 
-    if solver == :ipopt
-      if k == 2
-        mu_init = 1e-4
-      elseif k == 4
-        mu_init = 1e-5
-      elseif k == 6
-        mu_init = 1e-6
-      elseif k == 8
-        mu_init = 1e-7
-      elseif k == 10
-        mu_init = 1e-8
-      end
+    # solve subproblem
+    subsolver(ncl, k, ω, x0 = xr)
 
-      inner_stats = _solve_ipopt(
-        ncl;
-        x0 = xr,
-        warm_start_init_point = k > 1 ? "yes" : "no",
-        mu_init = mu_init,
-        tol = ω,
-        ipopt_options...,
-        kwargs...,
-      )
+    failed(sub_stats) && @warn "subsolver returns with status " sub_stats.status
 
-      # warm-starting multipliers appears to help IPOPT
-      ipopt_options[:y0] = inner_stats.multipliers
-      if has_bounds(ncl.nlp)
-        ipopt_options[:zL0] = inner_stats.multipliers_L
-        ipopt_options[:zU0] = inner_stats.multipliers_U
-      end
-
-    elseif solver == :knitro
-      if k == 2
-        mu_init = 1e-3
-        knitro_options[:bar_slackboundpush] = 1.0e-3
-        knitro_options[:bar_murule] = 1
-      elseif k == 4
-        mu_init = 1e-5
-        knitro_options[:bar_slackboundpush] = 1.0e-5
-      elseif k == 6
-        mu_init = 1e-6
-        knitro_options[:bar_slackboundpush] = 1.0e-6
-      elseif k == 8
-        mu_init = 1e-7
-        knitro_options[:bar_slackboundpush] = 1.0e-7
-      elseif k == 10
-        mu_init = 1e-8
-        knitro_options[:bar_slackboundpush] = 1.0e-8
-      end
-      knitro_options[:bar_initmu] = mu_init
-      knitro_options[:opttol] = ω
-      knitro_options[:feastol] = ω
-      knitro_options[:opttol_abs] = ω0
-      knitro_options[:feastol_abs] = ω0
-      inner_stats = _solve_knitro(ncl; x0 = xr, knitro_options..., kwargs...)
-
-      # warm-starting multipliers doesn't seem to help KNITRO
-      # knitro_options[:y0] = inner_stats.multipliers
-      # knitro_options[:z0] = inner_stats.multipliers_L
-    else
-      error("The solver $solver is not supported.")
-    end
-
-    inner_stats.status == :first_order ||
-      @warn "inner solver returns with status" inner_stats.status
-
-    xr = inner_stats.solution
+    xr = sub_stats.solution
     x = xr[1:nx]
     r = xr[(nx + 1):(nx + nr)]
     rNorm = norm(r, Inf)
-    dual_feas = inner_stats.dual_feas
-    inner = inner_stats.iter
-    Δt = inner_stats.elapsed_time
+    dual_feas = sub_stats.dual_feas
+    inner = sub_stats.iter
+    Δt = sub_stats.elapsed_time
     t += Δt
 
     iter_count += inner
@@ -169,7 +108,7 @@ function NCLSolve(
         dual_feas,
         ω,
         ncl.ρ,
-        mu_init,
+        mu_init(subsolver),
         norm(ncl.y, Inf),
         norm(x),
         Δt
@@ -177,7 +116,7 @@ function NCLSolve(
     end
 
     if rNorm ≤ max(η, feas_tol)
-      ncl.y .+= ncl.ρ * r
+      ncl.y .+= ncl.ρ .* r
       η = η / τ_η
       ω = ω / τ_ω
 
@@ -222,16 +161,16 @@ function NCLSolve(
   elseif tired
     status = :max_iter
   else
-    status = inner_stats.status
+    status = sub_stats.status
   end
-  dual_feas = inner_stats.dual_feas
+  dual_feas = sub_stats.dual_feas
   primal_feas = η
   if has_bounds(ncl.nlp)
-    zL = inner_stats.multipliers_L[1:nx]
-    zU = inner_stats.multipliers_U[1:nx]
+    zL = sub_stats.multipliers_L[1:nx]
+    zU = sub_stats.multipliers_U[1:nx]
   end
 
-  stats = GenericExecutionStats(
+  ncl_stats = GenericExecutionStats(
     ncl.nlp,
     status = status,
     solution = x,
@@ -248,7 +187,7 @@ function NCLSolve(
     ),
   )
   if has_bounds(ncl.nlp)
-    set_bounds_multipliers!(stats, zL, zU)
+    set_bounds_multipliers!(ncl_stats, zL, zU)
   end
-  return stats
+  return ncl_stats
 end

--- a/src/NCLSolve.jl
+++ b/src/NCLSolve.jl
@@ -19,7 +19,9 @@ function NCLSolve(
   verbose::Bool = true,
   kwargs...,  # will be passed directly to inner solver
 )
-  @info "NCL: using subsolver $(name(subsolver))"
+  if verbose
+    @info "NCL: using subsolver $(name(subsolver))"
+  end
 
   NLPModels.reset!(ncl.nlp)
   NLPModels.reset!(ncl)
@@ -82,7 +84,7 @@ function NCLSolve(
     k += 1
 
     # solve subproblem
-    subsolver(ncl, k, ω, x0 = xr)
+    subsolver(ncl, k, ω; x0 = xr, kwargs...)
 
     failed(sub_stats) && @warn "subsolver returns with status " sub_stats.status
 

--- a/test/test_NCLSolve.jl
+++ b/test/test_NCLSolve.jl
@@ -1,19 +1,28 @@
 @testset "No solver by default" begin
-  @test isempty(NCL.available_solvers)
+  @test_throws ErrorException IpoptNCLSubSolver()
+  @test_throws ErrorException KnitroNCLSubSolver()
 end
 
 using NLPModelsIpopt
+using OptimizationProblems, OptimizationProblems.ADNLPProblems
 
 @testset "IPOPT solver available" begin
-  @test :ipopt ∈ NCL.available_solvers
+  model = hs16()
+  ncl_model = NCLModel(model)
+  sub = IpoptNCLSubSolver(ncl_model)
+  @test NCL.name(sub) == "IPOPT"
 end
 
-using OptimizationProblems, OptimizationProblems.ADNLPProblems
+@testset "IPOPT solver only supports Float64" begin
+  model = hs16(; type = Float32)
+  ncl_model = NCLModel(model)
+  @test_throws ErrorException IpoptNCLSubSolver(ncl_model)
+end
 
 @testset "Simple solve with IPOPT" begin
   model = hs16()
   ncl_model = NCLModel(model)
-  stats = NCLSolve(ncl_model, solver = :ipopt, verbose = false)
+  stats = NCLSolve(ncl_model, solver = :ipopt, verbose = true)
   @test stats.status == :first_order
 end
 

--- a/test/test_NCLSolve.jl
+++ b/test/test_NCLSolve.jl
@@ -22,7 +22,8 @@ end
 @testset "Simple solve with IPOPT" begin
   model = hs16()
   ncl_model = NCLModel(model)
-  stats = NCLSolve(ncl_model, solver = :ipopt, verbose = true)
+  subsolver = IpoptNCLSubSolver(ncl_model)
+  stats = NCLSolve(ncl_model; subsolver = subsolver, verbose = false)
   @test stats.status == :first_order
 end
 


### PR DESCRIPTION
A new abstract type allows support for additional subsolvers. As a result, the main NCL solver is short and streamlined. Both IPOPT and KNITRO solvers are restricted to models with element type Float64.