### PR TITLE
Run CI on self-hosted runner

### DIFF
--- a/.github/workflows/ci-m1.yml
+++ b/.github/workflows/ci-m1.yml
@@ -1,0 +1,29 @@
+name: Self-Hosted Test on PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+      - "*.toml"
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test:
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: macstadium
+      version: 1
+      arch: aarch64
+      allow_failure: false
+      run_codecov: false
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/test/test_NCLSolve.jl
+++ b/test/test_NCLSolve.jl
@@ -139,6 +139,8 @@ catch
 end
 
 if knitro_available
+  @info "KNITRO is available. Running KNITRO tests."
+
   using NLPModelsKnitro
 
   @testset "KNITRO solver available" begin


### PR DESCRIPTION
The self-hosted runner has a Knitro license and will run the Knitro unit tests.